### PR TITLE
Add OpenRouter LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 OPENAI_ENDPOINT=https://api.openai.com/v1
 OPENAI_API_KEY=
+OPENROUTER_ENDPOINT=https://openrouter.ai/api/v1
+OPENROUTER_API_KEY=
 
 ANTHROPIC_API_KEY=
 ANTHROPIC_ENDPOINT=https://api.anthropic.com

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We would like to officially thank [WarmShao](https://github.com/warmshao) for hi
 
 **WebUI:** is built on Gradio and supports most of `browser-use` functionalities. This UI is designed to be user-friendly and enables easy interaction with the browser agent.
 
-**Expanded LLM Support:** We've integrated support for various Large Language Models (LLMs), including: Google, OpenAI, Azure OpenAI, Anthropic, DeepSeek, Ollama etc. And we plan to add support for even more models in the future.
+**Expanded LLM Support:** We've integrated support for various Large Language Models (LLMs), including: Google, OpenAI, Azure OpenAI, Anthropic, DeepSeek, Ollama, OpenRouter etc. And we plan to add support for even more models in the future.
 
 **Custom Browser Support:** You can use your own browser with our tool, eliminating the need to re-login to sites or deal with other authentication challenges. This feature also supports high-definition screen recording.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       # LLM API Keys & Endpoints
       - OPENAI_ENDPOINT=${OPENAI_ENDPOINT:-https://api.openai.com/v1}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OPENROUTER_ENDPOINT=${OPENROUTER_ENDPOINT:-https://openrouter.ai/api/v1}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - ANTHROPIC_ENDPOINT=${ANTHROPIC_ENDPOINT:-https://api.anthropic.com}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -9,6 +9,7 @@ PROVIDER_DISPLAY_NAMES = {
     "unbound": "Unbound AI",
     "ibm": "IBM",
     "grok": "Grok",
+    "openrouter": "OpenRouter",
 }
 
 # Predefined model names for common providers
@@ -26,6 +27,11 @@ model_names = {
     "alibaba": ["qwen-plus", "qwen-max", "qwen-vl-max", "qwen-vl-plus", "qwen-turbo", "qwen-long"],
     "moonshot": ["moonshot-v1-32k-vision-preview", "moonshot-v1-8k-vision-preview"],
     "unbound": ["gemini-2.0-flash", "gpt-4o-mini", "gpt-4o", "gpt-4.5-preview"],
+    "openrouter": [
+        "openai/gpt-4o",
+        "google/gemini-2.5-pro",
+        "mistralai/mistral-small-3.2-24b-instruct",
+    ],
     "grok": [
         "grok-3",
         "grok-3-fast",

--- a/src/utils/llm_provider.py
+++ b/src/utils/llm_provider.py
@@ -205,6 +205,18 @@ def get_llm_model(provider: str, **kwargs):
             base_url=base_url,
             api_key=api_key,
         )
+    elif provider == "openrouter":
+        if not kwargs.get("base_url", ""):
+            base_url = os.getenv("OPENROUTER_ENDPOINT", "https://openrouter.ai/api/v1")
+        else:
+            base_url = kwargs.get("base_url")
+
+        return ChatOpenAI(
+            model=kwargs.get("model_name", "openai/gpt-4o"),
+            temperature=kwargs.get("temperature", 0.0),
+            base_url=base_url,
+            api_key=api_key,
+        )
     elif provider == "grok":
         if not kwargs.get("base_url", ""):
             base_url = os.getenv("GROK_ENDPOINT", "https://api.x.ai/v1")

--- a/tests/test_llm_api.py
+++ b/tests/test_llm_api.py
@@ -44,7 +44,8 @@ def get_env_value(key, provider):
         "mistral": {"api_key": "MISTRAL_API_KEY", "base_url": "MISTRAL_ENDPOINT"},
         "alibaba": {"api_key": "ALIBABA_API_KEY", "base_url": "ALIBABA_ENDPOINT"},
         "moonshot": {"api_key": "MOONSHOT_API_KEY", "base_url": "MOONSHOT_ENDPOINT"},
-        "ibm": {"api_key": "IBM_API_KEY", "base_url": "IBM_ENDPOINT"}
+        "ibm": {"api_key": "IBM_API_KEY", "base_url": "IBM_ENDPOINT"},
+        "openrouter": {"api_key": "OPENROUTER_API_KEY", "base_url": "OPENROUTER_ENDPOINT"}
     }
 
     if provider in env_mappings and key in env_mappings[provider]:
@@ -144,6 +145,11 @@ def test_ibm_model():
 def test_qwen_model():
     config = LLMConfig(provider="alibaba", model_name="qwen-vl-max")
     test_llm(config, "How many 'r's are in the word 'strawberry'?")
+
+
+def test_openrouter_model():
+    config = LLMConfig(provider="openrouter", model_name="openai/gpt-4o")
+    test_llm(config, "Describe this image", "assets/examples/test.png")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- include OpenRouter config and default models
- support OpenRouter in `get_llm_model`
- expose OpenRouter variables in docker and env example
- mention OpenRouter in README
- adjust tests for new provider

## Testing
- `pytest -q` *(fails: missing API keys and browser deps)*

------
https://chatgpt.com/codex/tasks/task_b_6861528482e88324b4bb403d9a7d574b