### PR TITLE
Dynamic OpenRouter model list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ langchain-ibm==0.3.10
 langchain_mcp_adapters==0.0.9
 langgraph==0.3.34
 langchain-community
+requests>=2.31
+python-dotenv>=1.0

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -13,6 +13,30 @@ PROVIDER_DISPLAY_NAMES = {
 }
 
 # Predefined model names for common providers
+import os
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+def fetch_openrouter_models() -> list[str]:
+    """Fetch available models from OpenRouter API."""
+    endpoint = os.getenv("OPENROUTER_ENDPOINT", "https://openrouter.ai/api/v1")
+    url = f"{endpoint.rstrip('/')}/models"
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        return [m.get("id") for m in data.get("data", []) if m.get("id")]
+    except Exception as e:
+        logger.warning(f"Failed to fetch models from OpenRouter: {e}")
+        return [
+            "openai/gpt-4o",
+            "google/gemini-2.5-pro",
+            "mistralai/mistral-small-3.2-24b-instruct",
+        ]
+
+
 model_names = {
     "anthropic": ["claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20240620", "claude-3-opus-20240229"],
     "openai": ["gpt-4o", "gpt-4", "gpt-3.5-turbo", "o3-mini"],
@@ -27,11 +51,7 @@ model_names = {
     "alibaba": ["qwen-plus", "qwen-max", "qwen-vl-max", "qwen-vl-plus", "qwen-turbo", "qwen-long"],
     "moonshot": ["moonshot-v1-32k-vision-preview", "moonshot-v1-8k-vision-preview"],
     "unbound": ["gemini-2.0-flash", "gpt-4o-mini", "gpt-4o", "gpt-4.5-preview"],
-    "openrouter": [
-        "openai/gpt-4o",
-        "google/gemini-2.5-pro",
-        "mistralai/mistral-small-3.2-24b-instruct",
-    ],
+    "openrouter": fetch_openrouter_models(),
     "grok": [
         "grok-3",
         "grok-3-fast",

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -17,11 +17,19 @@ def update_model_dropdown(llm_provider):
     Update the model name dropdown with predefined models for the selected provider.
     """
     # Use predefined models for the selected provider
+    if llm_provider == "openrouter":
+        models = config.fetch_openrouter_models()
+        config.model_names[llm_provider] = models
     if llm_provider in config.model_names:
-        return gr.Dropdown(choices=config.model_names[llm_provider], value=config.model_names[llm_provider][0],
-                           interactive=True)
+        models = config.model_names[llm_provider]
+        return gr.Dropdown(
+            choices=models,
+            value=models[0] if models else "",
+            interactive=True,
+            filterable=True,
+        )
     else:
-        return gr.Dropdown(choices=[], value="", interactive=True, allow_custom_value=True)
+        return gr.Dropdown(choices=[], value="", interactive=True, allow_custom_value=True, filterable=True)
 
 
 async def update_mcp_server(mcp_file: str, webui_manager: WebuiManager):
@@ -74,6 +82,7 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
                 value=config.model_names[os.getenv("DEFAULT_LLM", "openai")][0],
                 interactive=True,
                 allow_custom_value=True,
+                filterable=True,
                 info="Select a model in the dropdown options or directly type a custom model name"
             )
         with gr.Row():
@@ -131,6 +140,7 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
                 label="Planner LLM Model Name",
                 interactive=True,
                 allow_custom_value=True,
+                filterable=True,
                 info="Select a model in the dropdown options or directly type a custom model name"
             )
         with gr.Row():


### PR DESCRIPTION
## Summary
- fetch model list from OpenRouter at runtime
- allow searching model dropdowns
- add `requests` and `python-dotenv` dependencies

## Testing
- `pytest -q tests` *(fails: missing API keys, async framework, and playwright browser)*

------
https://chatgpt.com/codex/tasks/task_b_68615ae5ea748324baabbe66146e54a7